### PR TITLE
Publish objects when their containers are only accessible for admins.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,13 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Publish objects when their containers are only accessible for admins.
+  You do that with ``security.declareObjectProtected(ManagePortal)``.
+  This fixes setting permissions for a workflow state.
+  You can turn this off by setting the new option
+  ``EXPERIMENTAL_PUBLISH_TRAVERSE_ACCEPT_IF_ONLY_FOR_ADMINS``
+  to false.
+  [maurits]
 
 Bug fixes:
 

--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,13 @@ The package looks for these environment variables:
     when an object with a name in the known names is published, we accept it without further checks.
     Default: true.
 
+``EXPERIMENTAL_PUBLISH_TRAVERSE_ACCEPT_IF_ONLY_FOR_ADMINS``
+    When this is set, if the publishable object is not protected but its container is *only* accessible for admins, we accept it anyway.
+    This can happen if its class has ``security.declareObjectProtected(ManagePortal)``,
+    like happens when you use the permissions form of a workflow state in the ZMI.
+    An admin in this case is someone with role Manager or Site Administrator.
+    Default: true.
+
 Accepted True values are: ``true``, ``t``, ``1``, ``yes``, ``y``.
 
 The defaults are intended to be reasonable for the latest official Plone versions, but the defaults may change.

--- a/src/experimental/publishtraverse/tests/test_unit.py
+++ b/src/experimental/publishtraverse/tests/test_unit.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+import os
+import string
+import unittest
+
+
+class TestHelperFunctions(unittest.TestCase):
+    """Test helper functions.
+    """
+
+    def test_allow_object(self):
+        from experimental.publishtraverse.traverser import allow_object
+        # This should be True if we pass in Manager and/or Site Administrator,
+        # and False if we pass in anything else.
+        self.assertTrue(allow_object(['Manager']))
+        self.assertTrue(allow_object(('Manager',)))
+        self.assertTrue(allow_object(['Site Administrator']))
+        self.assertTrue(allow_object(['Manager', 'Site Administrator']))
+        self.assertFalse(allow_object(['Anonymous']))
+        self.assertFalse(allow_object(['Anonymous', 'Site Administrator']))
+        self.assertFalse(allow_object(['Manager', 'Member']))
+        self.assertFalse(allow_object(['Manager', 'Member',
+                                       'Site Administrator']))
+        self.assertFalse(allow_object([]))
+        # Test some unexpected input for good measure.
+        self.assertFalse(allow_object(None))
+        self.assertFalse(allow_object(''))
+        self.assertFalse(allow_object('python'))
+        self.assertFalse(allow_object(1))
+
+    def test_boolean_from_env(self):
+        from experimental.publishtraverse.traverser import (
+            boolean_from_env as be)
+        self.assertFalse(be('no such variable', False))
+        self.assertTrue(be('no such variable', True))
+
+        # Set an environment variable.
+        name = 'experimental_publish_traverse_test_variable'
+
+        # Only some values are read as True.
+        # See TRUE_VALUES in traverser.py
+        for value in ('true', 't', '1', 'yes', 'y'):
+            for trans in (string.lower, string.upper):
+                value = trans(value)
+                os.environ[name] = value
+                self.assertTrue(be(name, False),
+                                '{0} should be True'.format(value))
+
+        # All others are False.
+        for value in ('false', 'f', '0', 'no', 'n',
+                      'hello', 'ja', 'tru', 'yessir'):
+            for trans in (string.lower, string.upper):
+                value = trans(value)
+                os.environ[name] = value
+                self.assertFalse(be(name, True),
+                                 '{0} should be False'.format(value))
+
+        # cleanup
+        del os.environ[name]


### PR DESCRIPTION
You do that with `security.declareObjectProtected(ManagePortal)`.
This fixes setting permissions for a workflow state.

You can turn this off by setting the new option `EXPERIMENTAL_PUBLISH_TRAVERSE_ACCEPT_IF_ONLY_FOR_ADMINS` to false.

Internally, this also introduces a `boolean_from_env` helper function to read our options from the environment.